### PR TITLE
chore: add main queue setup for iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -272,7 +272,7 @@ PODS:
   - React-jsinspector (0.66.4)
   - React-logger (0.66.4):
     - glog
-  - react-native-ama (0.4.4):
+  - react-native-ama (0.4.6):
     - React-Core
   - react-native-safe-area-context (3.2.0):
     - React-Core
@@ -564,7 +564,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 94ce921e1d8ce7023366873ec371f3441383b396
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
-  react-native-ama: 0be920190515f12569f6f3c790609de83dce09d4
+  react-native-ama: 44f0f7752f7dbeb5a1ee148cf0c377266f4a39c3
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89

--- a/ios/Ama.swift
+++ b/ios/Ama.swift
@@ -1,6 +1,11 @@
 @objc(Ama)
 class Ama: NSObject {
 
+    @objc
+    static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     @objc(multiply:withB:withResolver:withRejecter:)
     func multiply(a: Float, b: Float, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
         resolve(a*b)


### PR DESCRIPTION
Fixes this warning on iOS. From new versions of react native you need to explicitly declare whether or not your module requires main queue setup.

<img width="50%" alt="Screenshot 2022-07-15 at 13 56 49" src="https://user-images.githubusercontent.com/6534400/179228935-290a0ffc-8a05-434d-ae02-b3aba55fce2e.png">
