### PR TITLE
Fix: ensure there is no `onClose` argument

### DIFF
--- a/lib/components/BottomSheet.test.tsx
+++ b/lib/components/BottomSheet.test.tsx
@@ -458,6 +458,30 @@ describe('BottomSheet', () => {
       expect(() => UNSAFE_getByType(KeyboardAvoidingView)).toThrow();
     },
   );
+
+  it('calls onClose correctly', () => {
+    const onClose = jest.fn();
+
+    const { getByTestId } = render(
+      <BottomSheet
+        topInset={0}
+        visible={true}
+        closeDistance={0.1}
+        onClose={onClose}
+        closeActionAccessibilityLabel={'close me'}
+        animationDuration={100}
+        headerComponent={<Text testID="Header">Header</Text>}
+        testID="bottom-sheet"
+      />,
+    );
+
+    act(() => {
+      const event = { some: 'props' };
+      getByTestId('bottom-sheet').props.onRequestClose(event);
+    });
+
+    expect(onClose).toHaveBeenCalledWith();
+  });
 });
 
 let useAnimatedGestureHandler: jest.Mock;

--- a/lib/components/BottomSheet.tsx
+++ b/lib/components/BottomSheet.tsx
@@ -225,7 +225,7 @@ export const BottomSheetBase = React.forwardRef<
         animationType="none"
         transparent={true}
         visible={isModalVisible}
-        onRequestClose={onClose}
+        onRequestClose={() => onClose()}
         ref={ref as any}
         testID={testID}>
         <Wrapper>


### PR DESCRIPTION
The Modal `onRequestClose` prop was calling the `onClose` callback with an `event` argument.
This PR calls `onClose` with no argument, as documented in the types.