### PR TITLE
Fixing viewProps type

### DIFF
--- a/lib/components/AutofocusContainer.tsx
+++ b/lib/components/AutofocusContainer.tsx
@@ -3,10 +3,9 @@ import { TouchableWithoutFeedback, View, ViewProps } from 'react-native';
 
 import { useFocus } from '../hooks/useFocus';
 
-type AutofocusContainerProps = React.PropsWithChildren<{
-  wrapChildrenInAccessibleView?: boolean;
-  viewProps?: ViewProps;
-}>;
+type AutofocusContainerProps = React.PropsWithChildren<
+  { wrapChildrenInAccessibleView?: boolean } & ViewProps
+>;
 
 export const AutofocusContainer = ({
   children,


### PR DESCRIPTION
The type for `viewProps` was incorrect. In the component definition it was used as the [`rest parameter` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) but defined in the `AutofocusContainerProps` type as a parameter


Either
```typescript
type AutofocusContainerProps = React.PropsWithChildren<
  { wrapChildrenInAccessibleView?: true } & ViewProps
>;

export const AutofocusContainer = ({
  children,
  wrapChildrenInAccessibleView = true,
  ...viewProps
}: AutofocusContainerProps)
```

Or 

```typescript
type AutofocusContainerProps = React.PropsWithChildren<{
  wrapChildrenInAccessibleView?: boolean;
  viewProps?: ViewProps;
}>;

export const AutofocusContainer = ({
  children,
  wrapChildrenInAccessibleView = true,
  viewProps
}: AutofocusContainerProps)
```

Should be used