### PR TITLE
Narrowing type definition

### DIFF
--- a/lib/components/AutofocusContainer.tsx
+++ b/lib/components/AutofocusContainer.tsx
@@ -4,7 +4,12 @@ import { TouchableWithoutFeedback, View, ViewProps } from 'react-native';
 import { useFocus } from '../hooks/useFocus';
 
 type AutofocusContainerProps = React.PropsWithChildren<
-  { wrapChildrenInAccessibleView?: boolean } & ViewProps
+  | ({
+      wrapChildrenInAccessibleView?: true;
+    } & ViewProps)
+  | {
+      wrapChildrenInAccessibleView: false;
+    }
 >;
 
 export const AutofocusContainer = ({


### PR DESCRIPTION
Since `ViewProps` are only spread into the `children's` parent view when `wrapChildrenInAccessibleView` is `true` or `undefined`*  then we should not allow the user of the component to pass `ViewProps` if `wrapChildrenInAccessibleView` is false. I have updated the type definition to reflect this.

`*` - undefined because we have set wrapChildrenInAccessibleView to true by default.