### PR TITLE
Fix `errorPosition` documentation for TextInput component

### DIFF
--- a/docs/components/TextInput.mdx
+++ b/docs/components/TextInput.mdx
@@ -192,7 +192,7 @@ The position where to render the [errorComponent](#errorcomponent)
 
 | Type            | Default      |
 |-----------------|--------------|
-| 'beforeInput' \| 'afterInput' | 'afterInput' |
+| 'belowLabel' \| 'afterInput' | 'afterInput' |
 
 ## Related guidelines
 


### PR DESCRIPTION
Corrects the documentation for `errorPosition` prop for the `TextInput` component.