### PR TITLE
fix: use `kotlin_version` from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-  def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['Ama_kotlinVersion']
+  def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : rootProject.ext.has('kotlin_version') ? rootProject.ext.get('kotlin_version') : project.properties['Ama_kotlinVersion']
 
   repositories {
     google()


### PR DESCRIPTION
It seems that other packages use `kotlin_version` instead of `kotlinVersion`, so this PR allows AMA to use either