### PR TITLE
Vercel docs setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,19 +52,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy docs (staging)
-        if: github.ref != 'refs/heads/main'
-        run: yarn deploy:stage
-        working-directory: ./website
-        env:
-          # GH actions have a PR merge commit that _isn't_ our actual commits.
-          # Manually infer correct branch and sha for pull requests.
-          FORMIDEPLOY_GIT_SHA: ${{ github.event.pull_request.head.sha }}
-          FORMIDEPLOY_PULL_REQUEST: ${{ steps.pr_info.outputs.pull_request_number }}
-          GITHUB_DEPLOYMENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-
       - name: Deploy docs (production)
         if: github.ref == 'refs/heads/main'
         run: yarn deploy:prod

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'React Native AMA',
   tagline: 'Accessible Mobile App Library for React Native',
   url: 'https://formidable.com',
-  baseUrl: '/open-source/react-native-ama/',
+  baseUrl: process.env.VERCEL_ENV === "preview" ? '/' : '/open-source/react-native-ama/',
   onBrokenLinks: 'error',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build --out-dir build/open-source/react-native-ama",
+    "build:vercel": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
This PR sets up Vercel for staging previews for docs (instead of Surge), and we'll soon use the Vercel deploy for prod docs as well.