### PR TITLE
fix: Typo in getting started docs

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -24,7 +24,7 @@ so these other dependencies should also be installed.
 ```bash npm2yarn
 npm install --save-dev react-native-reanimated
 npm install --save-dev react-native-gesture-handler
-npm install --save-dev wcga-color
+npm install --save-dev wcag-color
 
 cd ios
 pod install


### PR DESCRIPTION
The required dependency has a typo. 