### PR TITLE
suggested update to useTextInput example

### DIFF
--- a/docs/hooks/useTextInput.md
+++ b/docs/hooks/useTextInput.md
@@ -8,7 +8,7 @@ This hook can be used to create a custom TextInput keeping all the accessibility
 import { useTextInput } from 'react-native-ama';
 
 const MyTextInput = () => {
-    const { ref, ...rest } = useTextInput();
+    const { ref, ...rest } = useTextInput({...requiredProps});
     
     return <TextInput ref={ref} {...rest} />;
 }


### PR DESCRIPTION
The example suggests `useTextInput` hook can be called without  any props. This PR updates the example to reflect there are required props