### PR TITLE
docs: fix link in accessibility label page

### DIFF
--- a/docs/guidelines/accessibility-label.md
+++ b/docs/guidelines/accessibility-label.md
@@ -123,7 +123,7 @@ Is it possible to specify a list of allowed all caps accessibility labels, [more
 - [ExpandablePressable](../components/expandablepressable)
 - [Pressable](../components/pressable)
 - [TouchableOpacity](../components/touchableopacity)
-- [TouchableWithoutFeedback](../components/TouchableWithoutFeedback
+- [TouchableWithoutFeedback](../components/TouchableWithoutFeedback)
 
 ## External resources
 


### PR DESCRIPTION
I was just going through the docs and found this small issue in Markdown where the link for `TouchableWithoutFeedback` in [Accessibility Label](https://formidable.com/open-source/react-native-ama/guidelines/accessibility-label) is broken.