### PR TITLE
feat: creates helper `Form.Switch` component from `SwitchListItem` component

### DIFF
--- a/examples/shared/src/screens/Form.screen.tsx
+++ b/examples/shared/src/screens/Form.screen.tsx
@@ -55,7 +55,7 @@ export const FormScreen = () => {
         />
 
         <Spacer height="normal" />
-        <SwitchListItem
+        <Form.Switch
           labelComponent={
             <Text style={styles.switchText}>
               Test keyboard trap on next field

--- a/packages/forms/src/components/FormSwitch.tsx
+++ b/packages/forms/src/components/FormSwitch.tsx
@@ -1,0 +1,17 @@
+import {
+  SwitchListItem,
+  SwitchListItemProps,
+} from '@react-native-ama/react-native';
+import React from 'react';
+
+import { FormField } from './FormField';
+
+export type FormSwitchProps = SwitchListItemProps;
+
+export const FormSwitch = (props: FormSwitchProps) => {
+  return (
+    <FormField hasValidation={false}>
+      <SwitchListItem {...props} />
+    </FormField>
+  );
+};

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -6,16 +6,19 @@ import {
 } from './components/Form';
 import { FormField, FormFieldProps } from './components/FormField';
 import { FormSubmit, FormSubmitProps } from './components/FormSubmit';
+import { FormSwitch, FormSwitchProps } from './components/FormSwitch';
 
 type FormComponent = React.FunctionComponent<FormProps> & {
   Submit: (props: FormSubmitProps) => JSX.Element;
   Field: React.FunctionComponent<FormFieldProps>;
+  Switch: (props: FormSwitchProps) => JSX.Element;
 };
 
 // @ts-ignore
 const Form: FormComponent = FormProvider;
 Form.Submit = FormSubmit;
 Form.Field = FormField;
+Form.Switch = FormSwitch;
 
 export { Form, FormField, FormSubmit };
 
@@ -32,4 +35,5 @@ export {
   type FormActions,
   type FormFieldProps,
   type FormSubmitProps,
+  type FormSwitchProps,
 };

--- a/packages/react-native/src/components/SwitchListItem.tsx
+++ b/packages/react-native/src/components/SwitchListItem.tsx
@@ -1,5 +1,4 @@
 import { HideChildrenFromAccessibilityTree } from '@react-native-ama/core';
-import { FormField } from '@react-native-ama/forms';
 import { maybeGenerateStringFromElement } from '@react-native-ama/internal';
 import React from 'react';
 import type { StyleProp, SwitchProps, ViewStyle } from 'react-native';
@@ -7,7 +6,7 @@ import { StyleSheet, Switch } from 'react-native';
 
 import { SwitchWrapper } from './SwitchWrapper';
 
-type SwitchListItemProps = React.PropsWithChildren<
+export type SwitchListItemProps = React.PropsWithChildren<
   Omit<SwitchProps, 'style' | 'value' | 'onValueChange'> & {
     labelComponent: JSX.Element;
     labelPosition?: 'left' | 'right';
@@ -38,30 +37,28 @@ export const SwitchListItemBase = ({
   );
 
   return (
-    <FormField hasValidation={false}>
-      <SwitchWrapper
-        accessibilityLabel={accessibilityLabel}
-        style={[allStyles.container, style]}
-        onPress={onValueChange}
-        checked={value}
-        testID={testID}>
-        {isLabelPositionLeft ? labelComponent : null}
-        <HideChildrenFromAccessibilityTree>
-          {children ? (
-            children
-          ) : (
-            <Switch
-              {...rest}
-              style={switchStyle}
-              value={value}
-              onValueChange={onValueChange}
-              testID={`${testID}-switch`}
-            />
-          )}
-        </HideChildrenFromAccessibilityTree>
-        {isLabelPositionLeft ? null : labelComponent}
-      </SwitchWrapper>
-    </FormField>
+    <SwitchWrapper
+      accessibilityLabel={accessibilityLabel}
+      style={[allStyles.container, style]}
+      onPress={onValueChange}
+      checked={value}
+      testID={testID}>
+      {isLabelPositionLeft ? labelComponent : null}
+      <HideChildrenFromAccessibilityTree>
+        {children ? (
+          children
+        ) : (
+          <Switch
+            {...rest}
+            style={switchStyle}
+            value={value}
+            onValueChange={onValueChange}
+            testID={`${testID}-switch`}
+          />
+        )}
+      </HideChildrenFromAccessibilityTree>
+      {isLabelPositionLeft ? null : labelComponent}
+    </SwitchWrapper>
   );
 };
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,9 @@
 // Components
 export { ExpandablePressable } from './components/ExpandablePressable';
-export { SwitchListItem } from './components/SwitchListItem';
+export {
+  SwitchListItem,
+  type SwitchListItemProps,
+} from './components/SwitchListItem';
 export { SwitchWrapper } from './components/SwitchWrapper';
 export { Text } from './components/Text';
 export {


### PR DESCRIPTION
This PR  `Form.Switch` component which wraps `SwitchListItem` component with `FormField` component to handle all useForm props. This allows `SwitchListItem` to be used outside of `FormProvider`