### PR TITLE
Make ScrollView optional

### DIFF
--- a/examples/shared/src/screens/BottomSheet.screen.tsx
+++ b/examples/shared/src/screens/BottomSheet.screen.tsx
@@ -30,8 +30,8 @@ export const BottomSheetScreen: React.FC<TimedActionProps> = () => {
         }
         scrollViewProps={{
           style: styles.modalViewContent,
-        }}
-        scrollEnabled={true}>
+          scrollEnabled: true,
+        }}>
         <FormScreen />
       </BottomSheet>
       <CTAPressable

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -219,7 +219,7 @@ A testID to be used by the BottomSheet. The `Modal` component within the `Bottom
 | ------ |
 | string |
 
-### <Required /> ` `topInset`
+### <Required /> `topInset`
 
 The value is used to calculate the correct max ScrollView height.
 
@@ -239,9 +239,9 @@ The BottomSheet visibility
 
 A `ref` object used to call `close` and `isVisible` functions on the bottomSheet
 
-| Type                                                      |
-| --------------------------------------------------------- | --- |
-| { close: () => Promise<void>; isVisible: () => boolean; } |     |
+| Type                                                        |
+| ----------------------------------------------------------- |
+| `{ close: () => Promise<void>; isVisible: () => boolean; }` |
 
 ## Known issues
 

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -83,6 +83,14 @@ The accessibility label to use for the overlay button.
 | ------ |
 | string |
 
+### `closeDistance`
+
+A decimal fraction percentage of the content height which represents the minimum distance to swipe before the `onClose` function is run. For example, 0.3 represents 30% of the content height needing to be gesture swiped away before the `BottomSheet` will close and the `onClose` function will run.
+
+| Type   | Default |
+| ------ | ------- |
+| number | 0.3     |
+
 ### `footerComponent`
 
 The bottom sheet footer component.
@@ -130,6 +138,14 @@ The minimum velocity needed by quickly swiping down to close the bottom sheet.
 | Type   | Default                  |
 | ------ | ------------------------ |
 | number | 90% of the screen height |
+
+### `onBottomSheetHidden`
+
+The callback to triggered after animations when the BottomSheet is hidden
+
+| Type       |
+| ---------- |
+| () => void |
 
 ### <Required /> `onClose`
 
@@ -187,6 +203,22 @@ The props to use for the [`<ScrollView />`](https://reactnative.dev/docs/scrollv
 | --------------- | --------- |
 | scrollViewProps | undefined |
 
+### `shouldHandleKeyboardEvents`
+
+If true, keyboard events are handled internally by the `BottomSheet` allowing for scrolling and animations to run smoothly
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+### `testID`
+
+A testID to be used by the BottomSheet. The `Modal` component within the `BottomSheet` will receive this base `testID` and other internal components will receive abstractions of the base `testID`. It is best to view the source code to understand the hierarchy of these components and what testID's they will receive.
+
+| Type   |
+| ------ |
+| string |
+
 ### <Required /> ` `topInset`
 
 The value is used to calculate the correct max ScrollView height.
@@ -202,6 +234,14 @@ The BottomSheet visibility
 | Type    |
 | ------- |
 | boolean |
+
+### `ref`
+
+A `ref` object used to call `close` and `isVisible` functions on the bottomSheet
+
+| Type                                                      |
+| --------------------------------------------------------- | --- |
+| { close: () => Promise<void>; isVisible: () => boolean; } |     |
 
 ## Known issues
 

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -173,7 +173,7 @@ If true, the bottom sheet will not be closed when the user taps on the overlay; 
 
 ### `useScrollView`
 
-If true, children of `BottomSheet` are wrapped in a [`<ScrollView />`](https://reactnative.dev/docs/scrollview)
+If true, `children` of `BottomSheet` are wrapped in a [`<ScrollView />`](https://reactnative.dev/docs/scrollview)
 
 | Type    | Default |
 | ------- | ------- |

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -187,13 +187,13 @@ If true, the bottom sheet will not be closed when the user taps on the overlay; 
 | ------- | ------- |
 | boolean | true    |
 
-### `useScrollView`
+### `hasScrollableContent`
 
 If true, `children` of `BottomSheet` are wrapped in a [`<ScrollView />`](https://reactnative.dev/docs/scrollview)
 
 | Type    | Default |
 | ------- | ------- |
-| boolean | false   |
+| boolean | true   |
 
 ### `scrollViewProps`
 

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -1,0 +1,222 @@
+import { Required } from '@site/src/components';
+
+# BottomSheet
+
+AMA Provides an accessible bottom sheet built on top
+of [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)
+and [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler).
+
+## Example
+
+```jsx
+import { BottomSheet } from '@react-native-ama/extras
+
+const Component = () => (
+  <BottomSheet
+    visible={modalVisible}
+    onRequestClose={() => {
+      setModalVisible(!modalVisible);
+    }}
+    closeActionAccessibilityLabel="close bottomsheet"
+    bottomSheetStyle={styles.modalView}
+    headerComponent={
+      <View style={{ paddingHorizontal: theme.padding.big }}>
+        <Header title="This is the bottom sheet" />
+      </View>
+    }
+    scrollViewStyle={styles.modalViewContent}>
+    <Pressable
+      onPress={() => setModalVisible(!modalVisible)}
+      accessibilityRole="button">
+      <Text>Close bottom sheet</Text>
+    </Pressable>
+  </BottomSheet>
+);
+```
+
+## Accessibility
+
+- Checks that the `closeActionAccessibilityLabel` is a valid [accessibilityLabel](./guidelines/accessibility-label)
+- Provides a way [to close the bottom sheet](../guidelines/bottomsheet#2-can-be-dismissed) when the user taps on the overlay
+- Makes sure that the overlay is announced as "button"
+- Uses slide-in and slide-out animation **only** if the [Reduce Motion] (https://reactnative.dev/docs/accessibilityinfo) preference is turned off
+- Prevents the focus from [escaping the bottom sheet](../guidelines/bottomsheet#3-the-focus-stays-inside-it)
+- Provides a draggable area respecting the [minimum size](../guidelines/minimum-size)
+
+## Props
+
+### `animationDuration`
+
+The duration in milliseconds of the slide in/out animation.
+
+| Type   | Default |
+| ------ | ------- |
+| number | 300     |
+
+### `autoCloseDelay`
+
+The duration in milliseconds before auto-closing the bottom sheet
+
+| Type   | Default   |
+| ------ | --------- |
+| number | undefined |
+
+:::tip
+
+The auto-close will respect the user [Timed action](./guidelines/timed-actions) preference.
+
+:::
+
+### `bottomSheetStyle`
+
+The style to use for the bottom sheet panel
+
+| Type      | Default                                      |
+| --------- | -------------------------------------------- |
+| ViewStyle | `{ width: '100%', backgroundColor: '#fff' }` |
+
+### <Required /> `closeActionAccessibilityLabel`
+
+The accessibility label to use for the overlay button.
+
+| Type   |
+| ------ |
+| string |
+
+### `footerComponent`
+
+The bottom sheet footer component.
+
+| Type        |
+| ----------- |
+| JSX.Element |
+
+### `handleComponent`
+
+It can be used to either disable the default handle "line" or replace it with a custom component.
+
+| Type                    |
+| ----------------------- |
+| JSX.Element \| `'none'` |
+
+### `handleStyle`
+
+The style for the draggable line
+
+| Type      | Default                                                                                                                    |
+| --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| ViewStyle | `{ width: 48, height: 4, backgroundColor: 'grey', alignSelf: 'center', marginBottom: 24, borderRadius: 2, marginTop: 12 }` |
+
+### `headerComponent`
+
+The bottom sheet header component.
+
+| Type        |
+| ----------- |
+| JSX.Element |
+
+### `maxHeight`
+
+The maximum height of the bottom sheet.
+
+| Type   | Default                  |
+| ------ | ------------------------ |
+| number | 90% of the screen height |
+
+### `minVelocityToClose`
+
+The minimum velocity needed by quickly swiping down to close the bottom sheet.
+
+| Type   | Default                  |
+| ------ | ------------------------ |
+| number | 90% of the screen height |
+
+### <Required /> `onClose`
+
+The callback to trigger when the BottomSheet is dismissed
+
+| Type       |
+| ---------- |
+| () => void |
+
+### `overlayOpacity`
+
+The opacity of the overlay.
+
+| Type   | Default |
+| ------ | ------- |
+| number | 1       |
+
+### `overlayStyle`
+
+The style to use for the overlay
+
+| Type      | Default                                              |
+| --------- | ---------------------------------------------------- |
+| ViewStyle | `{ backgroundColor: 'rgba(0, 0, 0, 0.5)', flex: 1 }` |
+
+### `panGestureEnabled`
+
+Enable or disable the dragging gesture.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+### `persistent`
+
+If true, the bottom sheet will not be closed when the user taps on the overlay; the dragging gesture is also disabled.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+### `useScrollView`
+
+If true, children of `BottomSheet` are wrapped in a [`<ScrollView />`](https://reactnative.dev/docs/scrollview)
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+### `scrollViewProps`
+
+The props to use for the [`<ScrollView />`](https://reactnative.dev/docs/scrollview) that wraps the BottomSheet content
+
+| Type            | Default   |
+| --------------- | --------- |
+| scrollViewProps | undefined |
+
+### <Required /> ` `topInset`
+
+The value is used to calculate the correct max ScrollView height.
+
+| Type   | Default |
+| ------ | ------- |
+| number | 0       |
+
+### <Required /> `visible`
+
+The BottomSheet visibility
+
+| Type    |
+| ------- |
+| boolean |
+
+## Known issues
+
+If the app crashes with the following error:
+
+> Unsupported top level event type "onGestureHandlerStateChange" dispatched
+
+Add the following import at the top of your `App.tsx|jsx` file:
+
+```js
+// https://github.com/software-mansion/react-native-gesture-handler/issues/320
+import 'react-native-gesture-handler';
+```
+
+## Related guidelines
+
+- [BottomSheet](../guidelines/bottomsheet)
+- [Focus](../guidelines/focus)

--- a/packages/extras/src/components/BottomSheet.tsx
+++ b/packages/extras/src/components/BottomSheet.tsx
@@ -51,14 +51,13 @@ export type BottomSheetProps = {
   overlayStyle?: ViewStyle | ViewStyle[];
   panGestureEnabled?: boolean;
   persistent?: boolean;
-  scrollEnabled?: boolean;
-  scrollViewProps?: Omit<ScrollViewProps, 'scrollEnabled'>;
+  useScrollView?: boolean;
   testID?: string;
   topInset: number;
   visible: boolean;
   ref?: React.RefObject<BottomSheetActions>;
   shouldHandleKeyboardEvents?: boolean;
-};
+} & Omit<ScrollViewWrapperProps, 'testID' | 'maxScrollViewHeight'>;
 
 export type BottomSheetActions = {
   close: () => Promise<void>;
@@ -87,6 +86,7 @@ export const BottomSheet = React.forwardRef<
       handleComponent,
       scrollEnabled = false,
       scrollViewProps,
+      useScrollView,
       persistent = false,
       autoCloseDelay,
       panGestureEnabled = true,
@@ -258,6 +258,8 @@ export const BottomSheet = React.forwardRef<
       ? 1
       : 0;
 
+    const ContentWrapper = useScrollView ? ScrollViewWrapper : FragmentWrapper;
+
     return (
       <Modal
         animationType="none"
@@ -331,16 +333,13 @@ export const BottomSheet = React.forwardRef<
                       }}>
                       {headerComponent}
                     </View>
-                    <ScrollView
+                    <ContentWrapper
                       {...scrollViewProps}
-                      style={[
-                        { maxHeight: maxScrollViewHeight },
-                        scrollViewProps?.style,
-                      ]}
                       scrollEnabled={scrollEnabled}
-                      testID={`${testID}-scrollview`}>
+                      testID={`${testID}-scrollview`}
+                      maxScrollViewHeight={maxScrollViewHeight}>
                       {children}
-                    </ScrollView>
+                    </ContentWrapper>
                     <View
                       onLayout={event => {
                         setFooterHeight(event.nativeEvent.layout.height);
@@ -412,6 +411,39 @@ const GestureHandler = ({
       <Animated.View>{children}</Animated.View>
     </PanGestureHandler>
   );
+};
+
+type ScrollViewWrapperProps = {
+  scrollViewProps?: Omit<ScrollViewProps, 'scrollEnabled'>;
+  scrollEnabled?: boolean;
+  testID?: string;
+  maxScrollViewHeight: number;
+};
+
+const ScrollViewWrapper: React.FC<
+  React.PropsWithChildren<ScrollViewWrapperProps>
+> = ({
+  scrollViewProps,
+  scrollEnabled,
+  testID,
+  maxScrollViewHeight,
+  children,
+}) => {
+  return (
+    <ScrollView
+      {...scrollViewProps}
+      style={[{ maxHeight: maxScrollViewHeight }, scrollViewProps?.style]}
+      scrollEnabled={scrollEnabled}
+      testID={`${testID}-scrollview`}>
+      {children}
+    </ScrollView>
+  );
+};
+
+const FragmentWrapper: React.FC<React.PropsWithChildren<any>> = ({
+  children,
+}) => {
+  return <>{children}</>;
 };
 
 const styles = StyleSheet.create({

--- a/packages/extras/src/components/BottomSheet.tsx
+++ b/packages/extras/src/components/BottomSheet.tsx
@@ -52,12 +52,16 @@ export type BottomSheetProps = {
   panGestureEnabled?: boolean;
   persistent?: boolean;
   useScrollView?: boolean;
+  scrollViewProps?: Omit<
+    ScrollViewWrapperProps,
+    'testID' | 'maxScrollViewHeight'
+  >;
   testID?: string;
   topInset: number;
   visible: boolean;
   ref?: React.RefObject<BottomSheetActions>;
   shouldHandleKeyboardEvents?: boolean;
-} & Omit<ScrollViewWrapperProps, 'testID' | 'maxScrollViewHeight'>;
+};
 
 export type BottomSheetActions = {
   close: () => Promise<void>;
@@ -84,7 +88,6 @@ export const BottomSheet = React.forwardRef<
       animationDuration = 300,
       closeDistance = 0.3,
       handleComponent,
-      scrollEnabled = false,
       scrollViewProps,
       useScrollView,
       persistent = false,
@@ -335,7 +338,6 @@ export const BottomSheet = React.forwardRef<
                     </View>
                     <ContentWrapper
                       {...scrollViewProps}
-                      scrollEnabled={scrollEnabled}
                       testID={`${testID}-scrollview`}
                       maxScrollViewHeight={maxScrollViewHeight}>
                       {children}
@@ -414,25 +416,22 @@ const GestureHandler = ({
 };
 
 type ScrollViewWrapperProps = {
-  scrollViewProps?: Omit<ScrollViewProps, 'scrollEnabled'>;
-  scrollEnabled?: boolean;
   testID?: string;
   maxScrollViewHeight: number;
-};
+} & ScrollViewProps;
 
-const ScrollViewWrapper: React.FC<
-  React.PropsWithChildren<ScrollViewWrapperProps>
-> = ({
-  scrollViewProps,
-  scrollEnabled,
+const ScrollViewWrapper: React.FC<ScrollViewWrapperProps> = ({
+  scrollEnabled = false,
   testID,
   maxScrollViewHeight,
   children,
+  style,
+  ...rest
 }) => {
   return (
     <ScrollView
-      {...scrollViewProps}
-      style={[{ maxHeight: maxScrollViewHeight }, scrollViewProps?.style]}
+      {...rest}
+      style={[{ maxHeight: maxScrollViewHeight }, style]}
       scrollEnabled={scrollEnabled}
       testID={`${testID}-scrollview`}>
       {children}

--- a/packages/extras/src/components/BottomSheet.tsx
+++ b/packages/extras/src/components/BottomSheet.tsx
@@ -51,7 +51,7 @@ export type BottomSheetProps = {
   overlayStyle?: ViewStyle | ViewStyle[];
   panGestureEnabled?: boolean;
   persistent?: boolean;
-  useScrollView?: boolean;
+  hasScrollableContent?: boolean;
   scrollViewProps?: Omit<
     ScrollViewWrapperProps,
     'testID' | 'maxScrollViewHeight'
@@ -89,7 +89,7 @@ export const BottomSheet = React.forwardRef<
       closeDistance = 0.3,
       handleComponent,
       scrollViewProps,
-      useScrollView,
+      hasScrollableContent = true,
       persistent = false,
       autoCloseDelay,
       panGestureEnabled = true,
@@ -261,7 +261,9 @@ export const BottomSheet = React.forwardRef<
       ? 1
       : 0;
 
-    const ContentWrapper = useScrollView ? ScrollViewWrapper : FragmentWrapper;
+    const ContentWrapper = hasScrollableContent
+      ? ScrollViewWrapper
+      : FragmentWrapper;
 
     return (
       <Modal

--- a/website/versioned_docs/version-0.7.x/components/BottomSheet.md
+++ b/website/versioned_docs/version-0.7.x/components/BottomSheet.md
@@ -183,7 +183,7 @@ The props to use for the [`<ScrollView />`](https://reactnative.dev/docs/scrollv
 | --------------- | --------- |
 | scrollViewProps | undefined |
 
-### <Required /> ` `topInset`
+### <Required /> `topInset`
 
 The value is used to calculate the correct max ScrollView height.
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

Allows not wrapping BottomSheet children inside a ScrollView. This allows the dev to have a different type of scrollable container, like FlatList, etc.

Fixes #210 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
