### PR TITLE
update useFocus Hook to handle animations and catch findNodeHandle errors

### DIFF
--- a/packages/core/src/hooks/useFocus.ts
+++ b/packages/core/src/hooks/useFocus.ts
@@ -1,6 +1,10 @@
 import { SHELL_COLORS } from '@react-native-ama/internal';
 import * as React from 'react';
-import { AccessibilityInfo, findNodeHandle } from 'react-native';
+import {
+  AccessibilityInfo,
+  InteractionManager,
+  findNodeHandle,
+} from 'react-native';
 
 export const useFocus = (refComponent?: React.RefObject<any>) => {
   const setFocus = React.useCallback(
@@ -11,18 +15,35 @@ export const useFocus = (refComponent?: React.RefObject<any>) => {
         | React.Component<any, any>
         | React.ComponentClass<any>,
     ) => {
-      // @ts-ignore
-      const elementId = findNodeHandle(component);
-
-      if (elementId) {
-        AccessibilityInfo.setAccessibilityFocus(elementId);
-        AccessibilityInfo.setAccessibilityFocus(elementId);
-      } else if (__DEV__) {
-        console.warn(
-          // @ts-ignore
-          `${SHELL_COLORS.BG_RED}AMA.${SHELL_COLORS.RESET} ${SHELL_COLORS.BLUE}useFocus${SHELL_COLORS.RESET}: ${SHELL_COLORS.YELLOW}Ref element not found${SHELL_COLORS.RESET}`,
-        );
+      if (!component) {
+        return;
       }
+
+      InteractionManager.runAfterInteractions(() => {
+        try {
+          const elementId = findNodeHandle(component);
+
+          if (elementId) {
+            AccessibilityInfo.setAccessibilityFocus(elementId);
+            setTimeout(() => {
+              AccessibilityInfo.setAccessibilityFocus(elementId); //ISSUE: https://github.com/facebook/react-native/issues/30097
+            }, 100);
+          } else if (__DEV__) {
+            console.warn(
+              // @ts-ignore
+              `${SHELL_COLORS.BG_RED}AMA.${SHELL_COLORS.RESET} ${SHELL_COLORS.BLUE}useFocus${SHELL_COLORS.RESET}: ${SHELL_COLORS.YELLOW}Ref element not found${SHELL_COLORS.RESET}`,
+            );
+          }
+        } catch (error) {
+          if (__DEV__) {
+            console.warn(
+              // @ts-ignore
+              `${SHELL_COLORS.BG_RED}AMA.${SHELL_COLORS.RESET} ${SHELL_COLORS.BLUE}useFocus${SHELL_COLORS.RESET}: ${SHELL_COLORS.YELLOW}Error finding node handle${SHELL_COLORS.RESET} \n`,
+              error,
+            );
+          }
+        }
+      });
     },
     [],
   );


### PR DESCRIPTION

### Description
There are certain cases where findNodeHandle may throw an error. We now catch this and log it when in dev mode instead of crashing the app. 

The focus hook has also been updated to handle on screen loads better where in certain cases it would not focus an element. setTimeout has been added to catch more of these cases. 


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
