### PR TITLE
Update `Form` to reduce re-renders and add `focusFieldAt` function to ref

### DIFF
--- a/examples/shared/src/screens/Form.screen.tsx
+++ b/examples/shared/src/screens/Form.screen.tsx
@@ -1,4 +1,4 @@
-import { Form, TextInput } from '@react-native-ama/forms';
+import { Form, FormActions, TextInput } from '@react-native-ama/forms';
 import { Text } from '@react-native-ama/react-native';
 import * as React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
@@ -12,6 +12,7 @@ export const FormScreen = () => {
   const [firstName, setFirstName] = React.useState('');
   const [lastName, setLastName] = React.useState('');
   const [testKeyboardTrap, setTestKeyboardTrap] = React.useState(false);
+  const formRef = React.useRef<FormActions>(null);
   const [invalidFields, setInvalidFields] = React.useState<{
     lastName: boolean;
     firstName: boolean;
@@ -36,7 +37,7 @@ export const FormScreen = () => {
 
   return (
     <ScrollView style={styles.view}>
-      <Form onSubmit={handleOnSubmit}>
+      <Form onSubmit={handleOnSubmit} ref={formRef}>
         <TextInput
           style={styles.input}
           placeholder=""

--- a/packages/forms/docs/Form.md
+++ b/packages/forms/docs/Form.md
@@ -198,11 +198,21 @@ The callback to be called when the [`TextInput`](./TextInput.mdx) `returnKeyboar
 | -------- |
 | callback |
 
-## Methods
+### `ref`
+
+The form provider reference provides access to `focusFirstInvalidField` and `focusFieldAt` methods.
+
+| Type                         | Default   |
+| ---------------------------- | --------- |
+| React.RefObject<FormActions> | undefined |
+
+## Methods (`FormActions`)
 
 ### `focusFirstInvalidField`
 
 This method lets you manually shift the focus to the first field that has an error.
+
+`focusFirstInvalidField: () => void;`
 
 ```
 // To manually focus the first invalid field
@@ -214,6 +224,12 @@ const focusInvalidField = () => {
     <Pressable onPress={focusInvalidField} />
 </Form>
 ```
+
+### `focusFieldAt`
+
+This method lets you manually shift the focus to any field controlled by the form. Simply call the method with the fieldNumber reference which is the zero-based index of the field in the list.
+
+`focusFieldAt: (fieldNumber: number) => void;`
 
 ## Related guidelines
 

--- a/packages/forms/docs/Form.md
+++ b/packages/forms/docs/Form.md
@@ -4,44 +4,54 @@ import { Required } from '@site/src/components';
 
 The `<Form />` component provides a "local" context for the [`TextInput`](./TextInput.mdx), [`FormField`](./FormField.md) and [`SwitchListItem`](./SwitchListItem.md) components.
 
-The provider hosts the hosts the `ref` values used by the [TextInput](./TextInput.mdx) to know which [`returnKey`](./TextInput.mdx#returnkeytype) and what would be the next field to focus.
+The provider hosts the `ref` values used by the [TextInput](./TextInput.mdx) to know which [`returnKey`](./TextInput.mdx#returnkeytype) and what would be the next field to focus.
 
 ## Usage
 
 ```jsx
 <Form onSubmit={handleSubmit} ref={ref}>
-    {...}
+  {...}
 </Form>
 ```
 
 ## Example
 
 ```jsx
-<Form onSubmit={handleSubmit}>
-  <TextInput
-    onChangeText={newText => setFirstName(newText)}
-    defaultValue={text}
-    label={<Text>First name:</Text>}
-  />
+import { Form, TextInput } from '@react-native-ama/forms';
+import { SwitchListItem } from '@react-native-ama/react-native';
 
-  <TextInput
-    onChangeText={newText => setLastName(newText)}
-    defaultValue={text}
-    label={<Text>Last name:</Text>}
-  />
+const ExampleForm = () => {
+  return (
+    <Form onSubmit={handleSubmit}>
+      <TextInput
+        onChangeText={newText => setFirstName(newText)}
+        defaultValue={text}
+        label={<Text>First name:</Text>}
+      />
 
-  <SwitchListItem
-    label={<Text>Subscribe me to the newsletter</Text>}
-    value={isSubscribed}
-    onValueChange={toggleSwitch}
-  />
+      <TextInput
+        onChangeText={newText => setLastName(newText)}
+        defaultValue={text}
+        label={<Text>Last name:</Text>}
+      />
 
-  <TextInput
-    onChangeText={newText => setEmailAddress(newText)}
-    defaultValue={text}
-    label={<Text>Email address:</Text>}
-  />
-</Form>
+      <SwitchListItem
+        label={<Text>Subscribe me to the newsletter</Text>}
+        value={isSubscribed}
+        onValueChange={toggleSwitch}
+      />
+
+      <TextInput
+        onChangeText={newText => setEmailAddress(newText)}
+        defaultValue={text}
+        label={<Text>Email address:</Text>}
+      />
+      <FormSubmit accessibilityLabel="Submit">
+        <CustomSubmitButton />
+      </FormSubmit>
+    </Form>
+  );
+};
 ```
 
 When the user interacts with this form:

--- a/packages/forms/docs/Form.md
+++ b/packages/forms/docs/Form.md
@@ -198,13 +198,13 @@ The callback to be called when the [`TextInput`](./TextInput.mdx) `returnKeyboar
 | -------- |
 | callback |
 
-### `ref`
+### `ref` _(optional)_
 
 The form provider reference provides access to `focusFirstInvalidField` and `focusFieldAt` methods.
 
-| Type                         | Default   |
-| ---------------------------- | --------- |
-| React.RefObject<FormActions> | undefined |
+| Type                           | Default   |
+| ------------------------------ | --------- |
+| React.RefObject\<FormActions\> | undefined |
 
 ## Methods (`FormActions`)
 

--- a/packages/forms/src/components/Form.tsx
+++ b/packages/forms/src/components/Form.tsx
@@ -5,6 +5,7 @@ import { InteractionManager } from 'react-native';
 
 export type FormProps = React.PropsWithChildren<{
   onSubmit: () => boolean | Promise<boolean>;
+  ref?: React.RefObject<FormActions>; // need to explicitly type for inference in <Form /> component
 }>;
 
 export type FormActions = {

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -23,7 +23,7 @@ Form.Submit = FormSubmit;
 Form.Field = FormField;
 Form.Switch = FormSwitch;
 
-export { Form, FormField, FormSubmit };
+export { Form, FormField, FormSubmit, FormSwitch };
 
 // Components
 export { TextInput } from './components/TextInput';

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -1,4 +1,7 @@
 // Components
+
+import { isFocused } from '@react-native-ama/internal';
+
 import {
   FormActions,
   FormProps,
@@ -28,6 +31,9 @@ export { TextInput } from './components/TextInput';
 // Hooks
 export { useFormField } from './hooks/useFormField';
 export { useTextInput } from './hooks/useTextInput';
+
+// utils
+export { isFocused };
 
 // Types
 export {


### PR DESCRIPTION
### Description
This PR pulls in some recent changes to make the Form Provider component more render friendly. It also adds a `focusFieldAt` function to be used by the consumer. Finally I have exported the `isFocused` util from the `form` package (previously only used internally)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
