### PR TITLE
Update docs to use URL links for cross plugin docs

### DIFF
--- a/packages/animations/docs/components/AnimatedContainer.md
+++ b/packages/animations/docs/components/AnimatedContainer.md
@@ -152,4 +152,4 @@ The container style
 
 ## Related guidelines
 
-- [Animations](../guidelines/animations)
+- [Animations](/guidelines/animations)

--- a/packages/animations/docs/hooks/useAnimation.mdx
+++ b/packages/animations/docs/hooks/useAnimation.mdx
@@ -249,4 +249,4 @@ The result is:
 
 ## Related guidelines
 
-- [Animations](../guidelines/animations)
+- [Animations](/guidelines/animations)

--- a/packages/animations/docs/hooks/useAnimationDuration.md
+++ b/packages/animations/docs/hooks/useAnimationDuration.md
@@ -2,7 +2,6 @@
 
 When passing a motion property, returns 0 if [Reduce Motion](../hooks/useAMAContext#isreducemotionenabled) is enabled otherwise the given value.
 
-
 ## Usage
 
 ```js
@@ -52,4 +51,4 @@ Because we specified `translateX` as the property we're going to use for the ani
 
 ## Related guidelines
 
-- [Animations](../guidelines/animations)
+- [Animations](/guidelines/animations)

--- a/packages/animations/docs/hooks/useReanimatedTiming.md
+++ b/packages/animations/docs/hooks/useReanimatedTiming.md
@@ -161,4 +161,4 @@ value.value = withSpring('translateX', Math.random());
 
 ## Related guidelines
 
-- [Animations](../guidelines/animations)
+- [Animations](/guidelines/animations)

--- a/packages/extras/docs/BottomSheet.md
+++ b/packages/extras/docs/BottomSheet.md
@@ -36,12 +36,12 @@ const Component = () => (
 
 ## Accessibility
 
-- Checks that the `closeActionAccessibilityLabel` is a valid [accessibilityLabel](./guidelines/accessibility-label)
-- Provides a way [to close the bottom sheet](../guidelines/bottomsheet#2-can-be-dismissed) when the user taps on the overlay
+- Checks that the `closeActionAccessibilityLabel` is a valid [accessibilityLabel](/guidelines/accessibility-label)
+- Provides a way [to close the bottom sheet](/guidelines/bottomsheet#2-can-be-dismissed) when the user taps on the overlay
 - Makes sure that the overlay is announced as "button"
 - Uses slide-in and slide-out animation **only** if the [Reduce Motion] (https://reactnative.dev/docs/accessibilityinfo) preference is turned off
-- Prevents the focus from [escaping the bottom sheet](../guidelines/bottomsheet#3-the-focus-stays-inside-it)
-- Provides a draggable area respecting the [minimum size](../guidelines/minimum-size)
+- Prevents the focus from [escaping the bottom sheet](/guidelines/bottomsheet#3-the-focus-stays-inside-it)
+- Provides a draggable area respecting the [minimum size](/guidelines/minimum-size)
 
 ## Props
 
@@ -63,7 +63,7 @@ The duration in milliseconds before auto-closing the bottom sheet
 
 :::tip
 
-The auto-close will respect the user [Timed action](./guidelines/timed-actions) preference.
+The auto-close will respect the user [Timed action](/guidelines/timed-actions) preference.
 
 :::
 
@@ -193,7 +193,7 @@ If true, `children` of `BottomSheet` are wrapped in a [`<ScrollView />`](https:/
 
 | Type    | Default |
 | ------- | ------- |
-| boolean | true   |
+| boolean | true    |
 
 ### `scrollViewProps`
 
@@ -266,5 +266,5 @@ import 'react-native-gesture-handler';
 
 ## Related guidelines
 
-- [BottomSheet](../guidelines/bottomsheet)
-- [Focus](../guidelines/focus)
+- [BottomSheet](/guidelines/bottomsheet)
+- [Focus](/guidelines/focus)

--- a/packages/forms/docs/Form.md
+++ b/packages/forms/docs/Form.md
@@ -233,4 +233,4 @@ This method lets you manually shift the focus to any field controlled by the for
 
 ## Related guidelines
 
-- [Forms](../guidelines/forms)
+- [Forms](/guidelines/forms)

--- a/packages/forms/docs/FormField.md
+++ b/packages/forms/docs/FormField.md
@@ -83,4 +83,4 @@ Form Fields are wrapped inside an accessible\* view by default, to disable this 
 
 ## Related guidelines
 
-- [Forms](../guidelines/forms)
+- [Forms](/guidelines/forms)

--- a/packages/forms/docs/FormSubmit.md
+++ b/packages/forms/docs/FormSubmit.md
@@ -34,4 +34,4 @@ This parameter is passed to the accessibilityState busy.
 
 ## Related guidelines
 
-- [Forms](../guidelines/forms)
+- [Forms](/guidelines/forms)

--- a/packages/forms/docs/useFormField.md
+++ b/packages/forms/docs/useFormField.md
@@ -42,4 +42,4 @@ button.
 
 ## Related guidelines
 
-- [Forms](../guidelines/forms)
+- [Forms](/guidelines/forms)

--- a/packages/forms/docs/useTextInput.md
+++ b/packages/forms/docs/useTextInput.md
@@ -132,7 +132,7 @@ This property is used to know if the input can display an error, in case of fail
 
 - Set the error, in case of failure, as part of the accessibilityHint
 
-Here can be find more information about [error handling in Forms](../guidelines/forms#errors)
+Here can be find more information about [error handling in Forms](/guidelines/forms#errors)
 
 | Type    | Default   |
 | ------- | --------- |
@@ -169,4 +169,4 @@ The required message to be announced by the screen reader as part of the accessi
 
 ## Related guidelines
 
-- [Forms](../guidelines/forms)
+- [Forms](/guidelines/forms)

--- a/packages/react-native/docs/Text.md
+++ b/packages/react-native/docs/Text.md
@@ -37,6 +37,6 @@ When `autofocus` is set to true, AMA forces the `accessibilityRole` to **header*
 
 ## Related guidelines
 
-- [Headers](../guidelines/headers)
-- [Accessibility Label](../guidelines/accessibility-label)
-- [Minimum Size](../guidelines/minimum-size)
+- [Headers](/guidelines/headers)
+- [Accessibility Label](/guidelines/accessibility-label)
+- [Minimum Size](/guidelines/minimum-size)

--- a/packages/react-native/docs/TouchableOpacity.mdx
+++ b/packages/react-native/docs/TouchableOpacity.mdx
@@ -150,7 +150,7 @@ const Test = () => {
 
 ## Related guidelines
 
-- [Accessibility Label](../guidelines/accessibility-label)
-- [Accessibility Role](../guidelines/accessibility-role)
-- [Contrast](../guidelines/contrast)
-- [Minimum Size](../guidelines/minimum-size)
+- [Accessibility Label](/guidelines/accessibility-label)
+- [Accessibility Role](/guidelines/accessibility-role)
+- [Contrast](/guidelines/contrast)
+- [Minimum Size](/guidelines/minimum-size)

--- a/website/docs/ama/usage.md
+++ b/website/docs/ama/usage.md
@@ -28,9 +28,9 @@ const App = () => {
 
 ## Example
 
-In the following Example the navigation animation are disabled when the user enables the [Reduce Motion](../guidelines/animations) setting.
+In the following Example the navigation animation are disabled when the user enables the [Reduce Motion](/guidelines/animations) setting.
 
-It also shows how to build a more accessible [form](../guidelines/forms) using the built-in components.
+It also shows how to build a more accessible [form](/guidelines/forms) using the built-in components.
 
 ```jsx
 import * as React from 'react';
@@ -156,7 +156,7 @@ export const HomeScreen = () => {
         <Pressable
             onPress={handleOnSubmit}
             accessibilityLabel="Submit"
-            accessibiltiyRole="button"
+            accessibilityRole="button"
         >
             <Text>Submit</Text>
         </Pressable>

--- a/website/guidelines/accessibility-label.md
+++ b/website/guidelines/accessibility-label.md
@@ -31,8 +31,7 @@ This is especially crucial for icon-only buttons, where the control lacks textua
 <Pressable
   onPress={contactUs}
   accessibilityRole="button"
-  accessibilityLabel="Contact us"
->
+  accessibilityLabel="Contact us">
   Contact us
 </Pressable>
 ```
@@ -158,7 +157,7 @@ This is used when a component has the `accessibilityLabel` prop in all caps.
 
 :::tip
 
-Is it possible to specify a list of allowed all caps accessibility labels, [more info here](../guidelines/guidelines.md)
+Is it possible to specify a list of allowed all caps accessibility labels, [more info here](/guidelines/guidelines.md)
 :::
 
 ## Related AMA components

--- a/website/guidelines/pour.md
+++ b/website/guidelines/pour.md
@@ -38,7 +38,7 @@ We must ensure the app is compatible with assistive technologies, including keyb
 - The app should be fully functional through keyboard inputs
 - [Users should be given ample time to complete tasks](/guidelines/timed-actions)
 - [The app should be designed in a way that minimizes the risk of triggering seizures or other involuntary reactions](/guidelines/animations)
-- [Focus order](../guidelines/focus), screen titles, [headings](/guidelines/headings), and [labels](/guidelines/accessibility-label) should be clearly defined to facilitate easy navigation
+- [Focus order](/guidelines/focus), screen titles, [headings](/guidelines/headings), and [labels](/guidelines/accessibility-label) should be clearly defined to facilitate easy navigation
 - The app should offer appropriately [sized touch targets](/guidelines/minimum-size) and alternative input methods
 
 ## Understandable

--- a/website/versioned_docs/version-0.7.x/introduction/usage.md
+++ b/website/versioned_docs/version-0.7.x/introduction/usage.md
@@ -144,7 +144,7 @@ export const HomeScreen = () => {
         <Pressable
             onPress={handleOnSubmit}
             accessibilityLabel="Submit"
-            accessibiltiyRole="button"
+            accessibilityRole="button"
         >
             <Text>Submit</Text>
         </Pressable>


### PR DESCRIPTION
### Description
Fixing links that are cross plugin to URL links

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### How Has This Been Tested?
Ran docusaurus 

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
