### PR TITLE
Updates links to previous Formidable site not Nearform

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.1-alpha.2",
   "description": "Accessibility as a First-Class Citizen with React Native AMA",
   "repository": "https://github.com/FormidableLabs/react-native-ama.git",
-  "homepage": "https://formidable.com/open-source/react-native-ama/",
+  "homepage": "https://commerce.nearform.com/open-source/react-native-ama/",
   "scripts": {
     "example:bare": "yarn --cwd examples/bare",
     "example:expo": "yarn --cwd examples/expo",

--- a/packages/internal/src/utils/logger.rules.ts
+++ b/packages/internal/src/utils/logger.rules.ts
@@ -67,37 +67,37 @@ export const RULES_HELP: Record<Rule, string> | null = __DEV__
   ? {
       NO_UNDEFINED: '',
       CONTRAST_FAILED:
-        'https://formidable.com/open-source/react-native-ama/guidelines/contrast',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/contrast',
       CONTRAST_FAILED_AAA:
-        'https://formidable.com/open-source/react-native-ama/guidelines/contrast',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/contrast',
       MINIMUM_SIZE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/minimum-size',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/minimum-size',
       UPPERCASE_TEXT_NO_ACCESSIBILITY_LABEL:
-        'https://formidable.com/open-source/react-native-ama/guidelines/text',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/text',
       NO_UPPERCASE_TEXT:
-        'https://formidable.com/open-source/react-native-ama/guidelines/text',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/text',
       NO_ACCESSIBILITY_LABEL:
-        'https://formidable.com/open-source/react-native-ama/guidelines/accessibility-labels',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/accessibility-labels',
       NO_ACCESSIBILITY_ROLE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/accessibility-role',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/accessibility-role',
       NO_KEYBOARD_TRAP:
-        'https://formidable.com/open-source/react-native-ama/guidelines/forms',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/forms',
       NO_FORM_LABEL:
-        'https://formidable.com/open-source/react-native-ama/guidelines/forms',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/forms',
       NO_FORM_ERROR:
-        'https://formidable.com/open-source/react-native-ama/guidelines/forms',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/forms',
       FLATLIST_NO_COUNT_IN_SINGULAR_MESSAGE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/lists-grids#number-of-results',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/lists-grids#number-of-results',
       FLATLIST_NO_COUNT_IN_PLURAL_MESSAGE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/lists-grids#number-of-results',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/lists-grids#number-of-results',
       BOTTOM_SHEET_CLOSE_ACTION:
-        'https://formidable.com/open-source/react-native-ama/guidelines/bottomsheet',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/bottomsheet',
       INCOMPATIBLE_ACCESSIBILITY_STATE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/accessibility-role',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/accessibility-role',
       INCOMPATIBLE_ACCESSIBILITY_ROLE:
-        'https://formidable.com/open-source/react-native-ama/guidelines/accessibility-role',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/accessibility-role',
       NO_FORM_LABEL_ENDING_WITH_ASTERISK:
-        'https://formidable.com/open-source/react-native-ama/guidelines/forms#labels',
+        'https://commerce.nearform.com/open-source/react-native-ama/guidelines/forms#labels',
     }
   : null;
 


### PR DESCRIPTION
### Description

This PR updates links that were previously pointing to Formidables hosted docs now hosted on Nearform commerce. (All links were being redirected anyway but now we just point to the correct docs)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
