### PR TITLE
feat: added accessibility props on AutofocusContainer's Touchable container

### DIFF
--- a/.changeset/fifty-rice-lick.md
+++ b/.changeset/fifty-rice-lick.md
@@ -1,0 +1,5 @@
+---
+'@react-native-ama/internal': patch
+---
+
+Added `PickAccessibleProps` type helper to AMA internal package

--- a/.changeset/six-goats-retire.md
+++ b/.changeset/six-goats-retire.md
@@ -1,0 +1,5 @@
+---
+'@react-native-ama/core': patch
+---
+
+Added `touchableContainerAccessibilityProps` prop to `AutofocusContainer` to fix issue with accessible view on container

--- a/packages/core/src/components/AutofocusContainer.tsx
+++ b/packages/core/src/components/AutofocusContainer.tsx
@@ -1,20 +1,37 @@
 import * as React from 'react';
-import { TouchableWithoutFeedback, View, ViewProps } from 'react-native';
+import {
+  TouchableWithoutFeedback,
+  TouchableWithoutFeedbackProps,
+  View,
+  ViewProps,
+} from 'react-native';
 
 import { useFocus } from '../hooks/useFocus';
+import { PickAccessibleProps } from '@react-native-ama/internal';
 
-type AutofocusContainerProps = React.PropsWithChildren<
-  | ({
-      wrapChildrenInAccessibleView?: true;
-    } & ViewProps)
-  | {
-      wrapChildrenInAccessibleView: false;
-    }
+type TouchableAccessibleProps =
+  PickAccessibleProps<TouchableWithoutFeedbackProps>;
+
+export type AutofocusContainerProps = React.PropsWithChildren<
+  (
+    | ({
+        wrapChildrenInAccessibleView?: true;
+      } & ViewProps)
+    | {
+        wrapChildrenInAccessibleView: false;
+      }
+  ) & {
+    /**
+     * touchableContainerAccessibilityProps is provided as a workaround for any accessibility props that need to be passed to the TouchableWithoutFeedback component which are not recognized on the accessible view.
+     */
+    touchableContainerAccessibilityProps?: TouchableAccessibleProps;
+  }
 >;
 
 export const AutofocusContainer = ({
   children,
   wrapChildrenInAccessibleView = true,
+  touchableContainerAccessibilityProps,
   ...viewProps
 }: AutofocusContainerProps) => {
   const containerRef = React.useRef(null);
@@ -27,7 +44,9 @@ export const AutofocusContainer = ({
   }, [setFocus]);
 
   return wrapChildrenInAccessibleView ? (
-    <TouchableWithoutFeedback ref={containerRef}>
+    <TouchableWithoutFeedback
+      ref={containerRef}
+      {...touchableContainerAccessibilityProps}>
       <View
         accessible={true}
         testID="autofocusContainer.accessibleView"
@@ -36,7 +55,9 @@ export const AutofocusContainer = ({
       </View>
     </TouchableWithoutFeedback>
   ) : (
-    <TouchableWithoutFeedback ref={containerRef}>
+    <TouchableWithoutFeedback
+      ref={containerRef}
+      {...touchableContainerAccessibilityProps}>
       {children}
     </TouchableWithoutFeedback>
   );

--- a/packages/internal/src/index.ts
+++ b/packages/internal/src/index.ts
@@ -62,4 +62,8 @@ export {
 export { IS_ANDROID, IS_IOS } from './utils/platformHelpers';
 
 // Types
-export { type AMAAccessibilityState, type AccessibilityRoles } from './types';
+export {
+  type AMAAccessibilityState,
+  type AccessibilityRoles,
+  type PickAccessibleProps,
+} from './types';

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -1,7 +1,16 @@
-/* istanbul ignore file */
 import type { AccessibilityState } from 'react-native';
 
 export type AMAAccessibilityState = Pick<AccessibilityState, 'busy'>;
+
+export type PickAccessibleProps<T> = {
+  [K in keyof T as K extends
+    | `${string}accessible${string}`
+    | `${string}accessibility${string}`
+    | `${string}Accessible${string}`
+    | `${string}Accessibility${string}`
+    ? K
+    : never]: T[K];
+};
 
 export type AccessibilityRoles =
   | {


### PR DESCRIPTION
### Description
Adds workaround where some accessible props are ignored on accessible view for AutofocusContainer. Specifically `accessibilityState`

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Tested on Android and iOS example app

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
