### PR TITLE
docs: Adds prop docs to `Loading` component docs

### DIFF
--- a/packages/extras/docs/components/Loading.md
+++ b/packages/extras/docs/components/Loading.md
@@ -2,7 +2,7 @@ import { Required } from '@site/src/components';
 
 # Loading
 
-AMA provides an accessible `<Loading ... />` component that auto focuses and announces the accessibility label and busy state. This component wraps the standard [React Native Activity Indicator](https://reactnative.dev/docs/activityindicator).
+AMA provides an accessible `<Loading ... />` component that auto focuses and announces the accessibility label and busy state. This component wraps the standard [React Native ActivityIndicator](https://reactnative.dev/docs/activityindicator).
 
 :::note
 The `Loading` component by default is absolutely positioned and will fill it's parents container. In the example below this would be the `<View>`. This behaviour can be overridden by the `Loading` components props. See props section below.

--- a/packages/extras/docs/components/Loading.md
+++ b/packages/extras/docs/components/Loading.md
@@ -2,7 +2,7 @@ import { Required } from '@site/src/components';
 
 # Loading
 
-AMA provides an accessible `<Loading ... />` component that auto focuses and announces the accessibility label and busy state. This component wraps the standard [React Native ActivityIndicator](https://reactnative.dev/docs/activityindicator).
+AMA provides an accessible `<Loading ... />` component that auto focuses and announces the accessibility label and busy state. This component wraps the standard [React Native Activity Indicator](https://reactnative.dev/docs/activityindicator).
 
 :::note
 The `Loading` component by default is absolutely positioned and will fill it's parents container. In the example below this would be the `<View>`. This behaviour can be overridden by the `Loading` components props. See props section below.

--- a/packages/extras/docs/components/Loading.md
+++ b/packages/extras/docs/components/Loading.md
@@ -30,3 +30,74 @@ const Screen = () => {
   );
 };
 ```
+
+## Props
+
+:::note
+If you want to control the position of the loading indicator you can pass a `style` prop to the `Loading` component which will add styles to the `Loading` containers view. Alternatively you can completely override the current containers style by passing a `containerProps` prop with a style object key-value pair.
+:::
+
+### <Required /> `isLoading`
+
+The isLoading state determines if the `Loading` component is returned and is required for the component to function.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+### `title`
+
+The text used in the `accessibilityLabel` and also shown below the activity indicator if `showTitle` is set to true (default).
+
+| Type   | Default   |
+| ------ | --------- |
+| string | 'Loading' |
+
+### `showTitle`
+
+Whether or not a title text should be shown below the activity indicator.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+### `style`
+
+A prop to add styles to use for the `Loading` component container view with style merging (style arrays).
+
+| Type      | Default   |
+| --------- | --------- |
+| ViewStyle | undefined |
+
+:::note
+
+<details>
+  <summary>Styles already applied to the `Loading` component container view</summary>
+Your styles will be merged with these styles:
+
+```{
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 100,
+  }
+```
+
+</details>
+:::
+
+### `containerProps`
+
+A prop to control any `Loading` component container view props.
+
+| Type                                        | Default   |
+| ------------------------------------------- | --------- |
+| Omit\<AutofocusContainerProps, 'children'\> | undefined |
+
+:::note
+The `Loading` component container is AMA's `AutofocusContainer` component. The `containerProps` prop is an object that will be spread onto the `AutofocusContainer` component.
+:::

--- a/packages/extras/docs/components/Loading.md
+++ b/packages/extras/docs/components/Loading.md
@@ -5,11 +5,7 @@ import { Required } from '@site/src/components';
 AMA provides an accessible `<Loading ... />` component that auto focuses and announces the accessibility label and busy state. This component wraps the standard [React Native ActivityIndicator](https://reactnative.dev/docs/activityindicator).
 
 :::note
-The `Loading` component by default is absolutely positioned and will fill it's parents container. In the example below this would be the `<View>`. This behaviour can be overridden by the `Loading` components props. See props section below.
-:::
-
-:::tip
-Use the `Loading` component it as a top-level component in your screen while data is being fetched or as a replacement for sections of your screen that are loading to prevent accessibility users from interacting with data that is stale.
+The `Loading` component by default is absolutely positioned and will fill it's parents container. This behavior can be overridden by the `Loading` components props. See [props](#props) section below.
 :::
 
 ## Example
@@ -30,6 +26,10 @@ const Screen = () => {
   );
 };
 ```
+
+:::tip
+Use the `Loading` component it as a top-level component in your screen while data is being fetched or as a replacement for sections of your screen that are loading to prevent accessibility users from interacting with data that is stale.
+:::
 
 ## Props
 
@@ -69,13 +69,13 @@ A prop to add styles to use for the `Loading` component container view with styl
 | --------- | --------- |
 | ViewStyle | undefined |
 
-:::note
-
-<details>
+<details open>
   <summary>Styles already applied to the `Loading` component container view</summary>
+ 
 Your styles will be merged with these styles:
 
-```{
+```css
+{
     position: 'absolute',
     top: 0,
     left: 0,
@@ -88,7 +88,6 @@ Your styles will be merged with these styles:
 ```
 
 </details>
-:::
 
 ### `containerProps`
 


### PR DESCRIPTION


### Description
This PR adds prop docs to the  `Loading` component docs

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### How Has This Been Tested?
Ran docs locally

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
